### PR TITLE
bug: Tag Optional Data Exporting

### DIFF
--- a/client/src/app/admin-dashboard/components/studies-control/studies-control.component.ts
+++ b/client/src/app/admin-dashboard/components/studies-control/studies-control.component.ts
@@ -90,19 +90,26 @@ export class StudiesControlComponent {
       return;
     }
 
-    this.downloadFile(flattenedData);
+    const headerElements = [
+      'responseID',
+      'videoURL',
+      'study',
+      'user',
+      ...Object.keys(tags[0].study.tagSchema.dataSchema.properties)
+    ];
+
+    this.downloadFile(headerElements, flattenedData);
   }
 
-  downloadFile(data: any[]) {
+  downloadFile(headerElements: string[], data: any[]) {
     const replacer = (_key: string, value: any) =>
       value === null ? '' : value; // specify how you want to handle null values here
-    const header = Object.keys(data[0]);
     const csv = data.map((row) =>
-      header
+      headerElements
         .map((fieldName) => JSON.stringify(row[fieldName], replacer))
         .join(',')
     );
-    csv.unshift(header.join(','));
+    csv.unshift(headerElements.join(','));
     const csvArray = csv.join('\r\n');
 
     const a = document.createElement('a');


### PR DESCRIPTION
Optional data wasn't always in the generated CSV

* Get the possible tag fields from the tag schema rather then the first tag